### PR TITLE
allow a load balancer ip to be defined for the chart.

### DIFF
--- a/charts/brigade-bitbucket-gateway/templates/gateway-bitbucket-service.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/gateway-bitbucket-service.yaml
@@ -10,6 +10,9 @@ metadata:
     type: bitbucket
 spec:
   type: {{ .Values.bitbucket.service.type }}
+  {{- if .Values.bitbucket.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.bitbucket.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - port: {{ .Values.bitbucket.service.externalPort }}
     targetPort: {{ .Values.bitbucket.service.internalPort }}

--- a/charts/brigade-bitbucket-gateway/values.yaml
+++ b/charts/brigade-bitbucket-gateway/values.yaml
@@ -30,6 +30,7 @@ bitbucket:
   service:
     name: brigade-bitbucket-service
     type: LoadBalancer
+    loadBalancerIP: ""
     externalPort: 7748
     internalPort: 7748
 


### PR DESCRIPTION
Hi, this request will allow the brigade gateway's service to have a custom load balancer IP. (static or other)

via CLI:
helm upgrade -i bb-gw ./charts/brigade-bitbucket-gateway --set bitbucket.service.loadBalancerIP=24.99.131.123

via values.yaml:
helm upgrade -i bb-gw ./charts/brigade-bitbucket-gateway --values=myValues.yaml