### PR TITLE
when RBAC is enabled, allow to list pods

### DIFF
--- a/charts/brigade-bitbucket-gateway/templates/gateway-bitbucket-role.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/gateway-bitbucket-role.yaml
@@ -24,6 +24,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "watch"]
 ---
 kind: RoleBinding
 apiVersion: {{ template "brigade.rbac.version" }}


### PR DESCRIPTION
Hey,
It seems that one group was missing to make it working as I was getting errors when `rbac` was enabled. I believe this is the same what we can find for `gitlab` variant.

Cheers,
Damian