### PR TITLE
readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ To fetch the Brigade Bitbucket Gateway chart from the registry:
 
 ```console
   export HELM_EXPERIMENTAL_OCI=1
-  helm chart pull ghcr.io/brigadecore/brigade-bitbucket-gateway:v0.2.0
-  helm chart export ghcr.io/brigadecore/brigade-bitbucket-gateway:v0.2.0 -d ~/charts
+  helm chart pull ghcr.io/brigadecore/brigade-bitbucket-gateway:v2.0.0-alpha.1
+  helm chart export ghcr.io/brigadecore/brigade-bitbucket-gateway:v2.0.0-alpha.1 -d ~/charts
 ```
 
 As this chart requires custom configuration as described above to function


### PR DESCRIPTION
The previous releases of this were all in the 0.x range.

In anticipation of a first alpha release of this, I'm changing the version number in the readme to v2.0.0-alpha.1 so that we are clearly denoting that this is _not_ a minor release continuing in the 0.x line.