### PR TITLE
push edge images after merge to v2 branch

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -98,7 +98,7 @@ async function runSuite(event: Event): Promise<void> {
     ),
     buildJob(event)
   ).run()
-  if (event.worker?.git?.ref == "master") {
+  if (event.worker?.git?.ref == "v2") {
     // Push "edge" images.
     //
     // npm packages MUST be semantically versioned, so we DON'T publish an


### PR DESCRIPTION
Noticed we didn't publish an edge image post-merge.

It's because we weren't checking for whether the merge was to the `v2` branch and were instead checking for `master`.

This PR fixes it.