### PR TITLE
chart fix: make setting ALLOWED_CLIENT_IPS not dependent on emittedEvents being defined

### DIFF
--- a/charts/brigade-bitbucket-gateway/templates/deployment.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/deployment.yaml
@@ -47,9 +47,9 @@ spec:
         {{ if .Values.brigade.emittedEvents }}
         - name: EMITTED_EVENTS
           value: {{ join "," .Values.brigade.emittedEvents | quote }}
+        {{ end }}
         - name: ALLOWED_CLIENT_IPS
           value: {{ join "," .Values.allowedClientIPs | quote }}
-        {{ end }}
         {{- if .Values.tls.enabled }}
         volumeMounts:
         - name: cert


### PR DESCRIPTION
Fixes #18