### PR TITLE
chart: remove duplicate labels and fix selectors

### DIFF
--- a/charts/brigade-bitbucket-gateway/templates/cert-secret.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/cert-secret.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "gateway.fullname" . }}-cert
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
-    {{- include "gateway.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.tls.generateSelfSignedCert }}

--- a/charts/brigade-bitbucket-gateway/templates/deployment.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/deployment.yaml
@@ -4,18 +4,15 @@ metadata:
   name: {{ include "gateway.fullname" . }}
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
-    {{- include "gateway.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
-      {{- include "gateway.labels" . | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "gateway.selectorLabels" . | nindent 8 }}
-        {{- include "gateway.labels" . | nindent 8 }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- if .Values.tls.enabled }}

--- a/charts/brigade-bitbucket-gateway/templates/ingress-cert-secret.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/ingress-cert-secret.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "gateway.fullname" . }}-ingress-cert
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
-    {{- include "gateway.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.ingress.tls.generateSelfSignedCert }}

--- a/charts/brigade-bitbucket-gateway/templates/ingress.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
   name: {{ include "gateway.fullname" . }}
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
-    {{- include "gateway.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/brigade-bitbucket-gateway/templates/service.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/service.yaml
@@ -20,4 +20,3 @@ spec:
     protocol: TCP
   selector:
     {{- include "gateway.selectorLabels" . | nindent 8 }}
-    {{- include "gateway.labels" . | nindent 8 }}


### PR DESCRIPTION
Critically important in this PR: selectors on deployments and services previously included version information and they're really not supposed to. Selectors are immutable, so this mistake is preventing upgrades.