### PR TITLE
add more linters

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -2,7 +2,7 @@ import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@br
 
 const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
 
-const goImg = "brigadecore/go-tools:v0.4.0"
+const goImg = "brigadecore/go-tools:v0.5.0"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.1.0"
 const helmImg = "brigadecore/helm-tools:v0.4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM brigadecore/go-tools:v0.4.0
+FROM brigadecore/go-tools:v0.5.0
 
 ARG VERSION
 ARG COMMIT

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.4.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.5.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -6,20 +6,25 @@ run:
 linters:
   disable-all: true
   enable:
+  - bodyclose
   - depguard
   # - dupl
   - errcheck
+  - exportloopref
+  - forcetypeassert
   - goconst
   - gocyclo
   - gofmt
   - goimports
   - golint
+  - gosec
   - govet
   - lll
   # - maligned
   - misspell
   - nakedret
   - prealloc
+  - unconvert
   - unparam
   - unused
 

--- a/internal/webhooks/service_test.go
+++ b/internal/webhooks/service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewService(t *testing.T) {
-	s := NewService(
+	s := NewService( // nolint: forcetypeassert
 		// Totally unusable client that is enough to fulfill the dependencies for
 		// this test...
 		&coreTesting.MockEventsClient{

--- a/main.go
+++ b/main.go
@@ -52,9 +52,7 @@ func main() {
 		router.StrictSlash(true)
 		router.Handle(
 			"/events",
-			http.HandlerFunc( // Make a handler from a function
-				ipFilter.Decorate(webhooksHandler.ServeHTTP),
-			),
+			ipFilter.Decorate(webhooksHandler.ServeHTTP),
 		).Methods(http.MethodPost)
 		router.HandleFunc("/healthz", libHTTP.Healthz).Methods(http.MethodGet)
 		serverConfig, err := serverConfig()


### PR DESCRIPTION
Requires https://github.com/brigadecore/go-tools/pull/16 to be merged and `brigadecore/go-tools:v0.5.0` to be released first, as that image will contain new and updated linters.