### PR TITLE
make multiarch build faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM brigadecore/go-tools:v0.5.0
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.5.0 as builder
 
 ARG VERSION
 ARG COMMIT
+ARG TARGETOS
+ARG TARGETARCH
 ENV CGO_ENABLED=0
 
 WORKDIR /
@@ -9,11 +11,11 @@ COPY . /
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-RUN go build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o bin/bitbucket-gateway \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \
   .
 
 FROM scratch
-COPY --from=0 /bin/ /brigade-bitbucket-gateway/bin/
+COPY --from=builder /bin/ /brigade-bitbucket-gateway/bin/
 ENTRYPOINT ["/brigade-bitbucket-gateway/bin/bitbucket-gateway"]


### PR DESCRIPTION
This PR includes changes that should have been in #46.

Cross-compiling for the target architecture on the native architecture is faster than emulating the target architecture and not cross-compiling.