### PR TITLE
use ClusterIP as the default service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Edit `~/brigade-bitbucket-gateway-values.yaml`, making the following changes:
 
 * `brigade.apiToken`: Service account token from step 2
 
+* `service.type`: If you plan to enable ingress (advanced), you can leave this
+  as its default -- `ClusterIP`. If you do not plan to enable ingress, you
+  probably will want to change this value to `LoadBalancer`.
+
 Save your changes to `~/brigade-bitbucket-gateway-values.yaml` and use the
 following command to install the gateway using the above customizations:
 
@@ -112,13 +116,15 @@ $ helm install brigade-bitbucket-gateway \
     --version v2.0.0-alpha.3 \
     --create-namespace \
     --namespace brigade-bitbucket-gateway \
-    --values ~/brigade-bitbucket-gateway-values.yaml
+    --values ~/brigade-bitbucket-gateway-values.yaml \
+    --wait \
+    --timeout 300s
 ```
 
 ### 3. (RECOMMENDED) Create a DNS Entry
 
-If you installed the gateway without enabling support for an ingress controller,
-this command should help you find the gateway's public IP address:
+If you overrode defaults and set `service.type` to `LoadBalancer`, use this
+command to find the gateway's public IP address:
 
 ```console
 $ kubectl get svc brigade-bitbucket-gateway \

--- a/charts/brigade-bitbucket-gateway/values.yaml
+++ b/charts/brigade-bitbucket-gateway/values.yaml
@@ -102,10 +102,15 @@ nodeSelector: {}
 tolerations: []
 
 service:
-  ## If you're going to use an ingress controller, you can change the service
-  ## type to CLusterIP.
-  type: LoadBalancer
-  # nodePort: 31700
+  ## If you're not going to use an ingress controller, you may want to change
+  ## this value to LoadBalancer for production deployments. If running
+  ## locally, you may want to change it to NodePort OR leave it as ClusterIP
+  ## and use `kubectl port-forward` to map a port on the local network
+  ## interface to the service.
+  type: ClusterIP
+  ## Host port the service will be mapped to when service type is either
+  ## NodePort or LoadBalancer. If not specified, Kubernetes chooses.
+  # nodePort:
 
 allowedClientIPs:
 - 13.52.5.96/28


### PR DESCRIPTION
This leads to a smoother install experience because we can use `--wait`.