### PR TITLE
doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,143 +7,33 @@
 
 <img width="100" align="left" src="logo.png">
 
-This is a work-in-progress
-[Brigade 2](https://github.com/brigadecore/brigade/tree/v2)
-compatible gateway that receives events 
+The Brigade Bitbucket Gateway receives events 
 ([webhooks](https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html))
-from Bitbucket and propagates them into Brigade 2's event bus.
+from Bitbucket, transforms them into Brigade
+[events](https://docs.brigade.sh/topics/project-developers/events/), and emits
+them into Brigade's event bus.
 
 <br clear="left"/>
 
-## Installation
+> ⚠️&nbsp;&nbsp;If you are familiar with the Brigade GitHub Gateway, be advised
+> that this gateway is not as full-featured as that one. At this time, it merely
+> offers parity with its predecessor -- the Brigade v1.x-compatible Bitbucket
+> Gateway -- meaning it only handles simple webhooks and does not offer
+> any integration with
+> [Bitbucket Cloud Apps](https://support.atlassian.com/bitbucket-cloud/docs/bitbucket-cloud-apps-overview/).
+>
+> A more full-featured successor to this gateway is something the Brigade
+> maintainers do wish to explore in collaboration with the Brigade community.
+> Please reach out on the
+> [Kubernetes/#brigade](https://kubernetes.slack.com/messages/C87MF1RFD) Slack
+> channel if you are interested in working on that.
 
-Prerequisites:
+## Creating Webhooks
 
-* A Bitbucket account
-
-* A Kubernetes cluster:
-    * For which you have the `admin` cluster role
-    * That is already running Brigade 2
-    * Capable of provisioning a _public IP address_ for a service of type
-      `LoadBalancer`. (This means you won't have much luck running the gateway
-      locally in the likes of kind or minikube unless you're able and willing to
-      mess with port forwarding settings on your router, which we won't be
-      covering here.)
-
-* `kubectl`, `helm` (commands below require Helm 3.7.0+), and `brig` (the
-  Brigade 2 CLI)
-
-### 1. Create a Service Account for the Gateway
-
-__Note:__ To proceed beyond this point, you'll need to be logged into Brigade 2
-as the "root" user (not recommended) or (preferably) as a user with the `ADMIN`
-role. Further discussion of this is beyond the scope of this documentation.
-Please refer to Brigade's own documentation.
-
-Using Brigade 2's `brig` CLI, create a service account for the gateway to use:
-
-```console
-$ brig service-account create \
-    --id brigade-bitbucket-gateway \
-    --description brigade-bitbucket-gateway
-```
-
-Make note of the __token__ returned. This value will be used in another step.
-_It is your only opportunity to access this value, as Brigade does not save it._
-
-Authorize this service account to create new events:
-
-```console
-$ brig role grant EVENT_CREATOR \
-    --service-account brigade-bitbucket-gateway \
-    --source brigade.sh/bitbucket
-```
-
-__Note:__ The `--source brigade.sh/bitbucket` option specifies that this service
-account can be used _only_ to create events having a value of
-`brigade.sh/bitbucket` in the event's `source` field. _This is a security
-measure that prevents the gateway from using this token for impersonating other
-gateways._
-
-### 2. Install the Bitbucket Gateway
-
-For now, we're using the [GitHub Container Registry](https://ghcr.io) (which is
-an [OCI registry](https://helm.sh/docs/topics/registries/)) to host our Helm
-chart. Helm 3.7 has _experimental_ support for OCI registries. In the event that
-the Helm 3.7 dependency proves troublesome for users, or in the event that this
-experimental feature goes away, or isn't working like we'd hope, we will revisit
-this choice before going GA.
-
-First, be sure you are using
-[Helm 3.7.0](https://github.com/helm/helm/releases/tag/v3.7.0) or greater and
-enable experimental OCI support:
-
-```console
-$ export HELM_EXPERIMENTAL_OCI=1
-```
-
-As this chart requires custom configuration as described above to function
-properly, we'll need to create a chart values file with said config.
-
-Use the following command to extract the full set of configuration options into
-a file you can modify:
-
-```console
-$ helm inspect values oci://ghcr.io/brigadecore/brigade-bitbucket-gateway \
-    --version v2.0.0-beta.3 > ~/brigade-bitbucket-gateway-values.yaml
-```
-
-Edit `~/brigade-bitbucket-gateway-values.yaml`, making the following changes:
-
-* `host`: Set this to the host name where you'd like the gateway to be
-  accessible.
-
-* `brigade.apiAddress`: Address of the Brigade API server, beginning with
-  `https://`
-
-* `brigade.apiToken`: Service account token from step 2
-
-* `service.type`: If you plan to enable ingress (advanced), you can leave this
-  as its default -- `ClusterIP`. If you do not plan to enable ingress, you
-  probably will want to change this value to `LoadBalancer`.
-
-Save your changes to `~/brigade-bitbucket-gateway-values.yaml` and use the
-following command to install the gateway using the above customizations:
-
-```console
-$ helm install brigade-bitbucket-gateway \
-    oci://ghcr.io/brigadecore/brigade-bitbucket-gateway \
-    --version v2.0.0-beta.3 \
-    --create-namespace \
-    --namespace brigade-bitbucket-gateway \
-    --values ~/brigade-bitbucket-gateway-values.yaml \
-    --wait \
-    --timeout 300s
-```
-
-### 3. (RECOMMENDED) Create a DNS Entry
-
-If you overrode defaults and set `service.type` to `LoadBalancer`, use this
-command to find the gateway's public IP address:
-
-```console
-$ kubectl get svc brigade-bitbucket-gateway \
-    --namespace brigade-bitbucket-gateway \
-    --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
-```
-
-If you overrode defaults and enabled support for an ingress controller, you
-probably know what you're doing well enough to track down the correct IP without
-our help. 😉
-
-With this public IP in hand, edit your name servers and add an `A` record
-pointing your domain to the public IP.
-
-### 4. Create Webhooks
-
-In your browser, go to your Bitbucket repository for which you'd like to send
-webhooks to this gateway. From the menu on the left, select __Repository
-settings__ and then __Webhooks__. On this page, click __Add webhooks__.
+After [installation](docs/INSTALLATION.md), browse to any of your Bitbucket
+repositories for which you'd like to send webhooks to this gateway. From the
+menu on the left, select __Repository settings__ and then __Webhooks__. On this
+page, click __Add webhooks__.
 
 * In the __Title__ field, add a name for your webhook. It must be unique to this
 repository.
@@ -152,72 +42,53 @@ repository.
   `https://<DNS hostname or publicIP>/events`. Note that Bitbucket will not
   permit URLs that it cannot reach.
 
+  > ⚠️&nbsp;&nbsp;Instructions for finding the public IP are in the
+  > [installation docs](docs/INSTALLATION.md).
+
 * Check the __Active__ checkbox.
 
-* If you're using a self-signed certificate (which you are unless you made
-  additional configuration changes when deploying the gateway), check the
-  __Skip certificate verification__ checkbox.
+* If you're using a self-signed certificate (again, refer to the
+  [installation docs](docs/INSTALLATION.md)), check the __Skip certificate
+  verification__ checkbox.
 
 * Check any/all triggers for which you'd like a webhook sent to this gateway.
 
 * Click __Save__
 
-__Note:__ Those who are also familiar with the Brigade GitHub Gateway might be
-perplexed at the lack of anything along the lines of a "shared secret" when
-configuring webhooks in Bitbucket. How then do webhook requests authenticate
-themselves to your gateway? In short, they do not. In practice, however, this
-does _not_ mean that just anyone can send webhooks (directly) to your gateway. 
+> ⚠️&nbsp;&nbsp;Those who are also familiar with the Brigade GitHub Gateway
+> might be perplexed at the lack of anything along the lines of a "shared
+> secret" when configuring webhooks in Bitbucket. How then do webhook requests
+> authenticate themselves to your gateway? In short, they do not. In practice,
+> however, this does _not_ mean that just anyone can send webhooks (directly) to
+> your gateway. 
+>
+> This gateway is pre-configured (see Helm chart configuration options) with a
+> list of allowed IPs / IP ranges for inbound requests. This list reflects the
+> IPs utilized by Bitbucket for outbound requests. This effectively prevents
+> anyone except Bitbucket from (successfully) sending webhooks to your gateway.
+>
+> This strategy does not, however, prevent any random Bitbucket user (who
+> happens to know the address of your gateway) from configuring their own
+> repositories to send webhooks your way. However, this matters very little,
+> because Brigade 2 operates on a subscription model and if none of your own
+> Brigade projects subscribe to events originating from the third-party
+> repository in question, nothing happens.
 
-This gateway is pre-configured (see Helm chart configuration options) with a
-list of allowed IPs / IP ranges for inbound requests. This list reflects the IPs
-utilized by Bitbucket for outbound requests. This effectively prevents anyone
-except Bitbucket from (successfully) sending webhooks to your gateway.
+## Subscribing
 
-This strategy does not, however, prevent any random Bitbucket user (who happens
-to know the address of your gateway) from configuring their own repositories to
-send webhooks your way. However, this matters very little, because Brigade 2
-operates on a subscription model and if none of your own Brigade projects
-subscribe to events originating from the third-party repository in question,
-nothing happens.
+Now subscribe any number of Brigade
+[projects](https://docs.brigade.sh/topics/project-developers/projects/)
+to events emitted by this gateway -- all of which have a value of
+`brigade.sh/bitbucket` in their `source` field. You can subscribe to all event
+types emitted by the gateway, or just specific ones.
 
-### 5. Add a Brigade Project
-
-You can create any number of Brigade projects (or modify an existing one) to
-listen for events that were sent from BitBucket to your gateway and, in turn,
-emitted into Brigade's event bus. You can subscribe to all event types emitted
-by the gateway, or just specific ones.
-
-In the example project definition below, we subscribe to all events emitted by
-the gateway, provided they've originated from the fictitious
-`example-org/example` repository (see the `repo` qualifier).
-
-```yaml
-apiVersion: brigade.sh/v2
-kind: Project
-metadata:
-  id: bitbucket-demo
-description: A project that demonstrates integration with Bitbucket
-spec:
-  eventSubscriptions:
-  - source: brigade.sh/bitbucket
-    types:
-    - *
-    qualifiers:
-      repo: example-org/example
-  workerTemplate:
-    defaultConfigFiles:
-      brigade.js: |-
-        const { events } = require("@brigadecore/brigadier");
-
-        events.on("brigade.sh/bitbucket", "issue:comment_created", () => {
-          console.log("Someone created a new issue in the example-org/example repository!");
-        });
-
-        events.process();
-```
-
-In the alternative example below, we subscribe _only_ to `issue:comment_created`
-events:
+In the example project definition below, we subscribe to
+`issue:created` events, provided they've originated from the fictitious
+`example-org/example` repository (see the `repo` 
+[qualifier](https://docs.brigade.sh/topics/project-developers/events/#qualifiers)).
+You should adjust this value to match a repository for which you are sending
+webhooks to your new gateway (see
+[installation instructions](docs/INSTALLATION.md)).
 
 ```yaml
 apiVersion: brigade.sh/v2
@@ -229,7 +100,7 @@ spec:
   eventSubscriptions:
   - source: brigade.sh/bitbucket
     types:
-    - issue:comment_created
+    - issue:created
     qualifiers:
       repo: example-org/example
   workerTemplate:
@@ -237,7 +108,7 @@ spec:
       brigade.js: |-
         const { events } = require("@brigadecore/brigadier");
 
-        events.on("brigade.sh/bitbucket", "issue:comment_created", () => {
+        events.on("brigade.sh/bitbucket", "issue:created", () => {
           console.log("Someone created a new issue in the example-org/example repository!");
         });
 
@@ -251,8 +122,8 @@ so:
 $ brig project create --file project.yaml
 ```
 
-Open an issue in the Bitbucket repo for which you configured webhooks to send an
-event (webhook) to your gateway. The gateway, in turn, will emit the event into
+Creating a new issue in the corresponding repo should now send a webhook from
+Bitbucket to your gateway. The gateway, in turn, will emit an event into
 Brigade's event bus. Brigade should initialize a worker (containerized event
 handler) for every project that has subscribed to the event, and the worker
 should execute the `brigade.js` script that was embedded in the project
@@ -265,54 +136,19 @@ $ brig event list --project bitbucket-demo
 ```
 
 Full coverage of `brig` commands is beyond the scope of this documentation, but
-at this point, additional `brig` commands can be applied to monitor the event's
-status and view logs produced in the course of handling the event.
+at this point,
+[additional `brig` commands](https://docs.brigade.sh/topics/project-developers/brig/)
+can be applied to monitor the event's status and view logs produced in the
+course of handling the event.
 
-## Events Received and Emitted by this Gateway
+## Further Reading
 
-Events received by this gateway from Bitbucket are, in turn, emitted into
-Brigade's event bus.
-
-Events received from BitBucket vary in _scope of specificity_. All events
-handled by this gateway are _at least_ indicative of activity involving some
-specific repository in some way -- for instance, a BitBucket user having forked
-a repository. Some events, however, are more specific than this, being
-indicative of activity involving not only a specific repository, but also some
-specific branch, tag, or commit -- for instance, a new pull request has been
-opened or a new tag has been pushed. In such cases (and only in such cases),
-this gateway includes git reference or commit information in the event that is
-emitted into Brigade's event bus. By doing so, Brigade (which has built in _git_
-support) is enabled to locate specific code affected by the event.
-
-The following table summarizes all Bitbucket event types that can be received by
-this gateway and the corresponding event types that are emitted into Brigade's
-event bus.
-
-| Bitbucket Event Type | Scope | Event Type(s) Emitted |
-|----------------------|-------|-----------------------|
-[`issue:comment_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-created) | specific repository | `issue:comment_created` |
-[`issue:created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Created) | specific repository | `issue:created` |
-[`issue:updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Updated.1) | specific repository | `issue:updated` |
-[`pullrequest:approved`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Approved) | specific commit | `pullrequest:approved` |
-[`pullrequest:comment_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-created.1) | specific commit | `pullrequest:comment_created` |
-[`pullrequest:comment_deleted`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-deleted) | specific commit | `pullrequest:comment_deleted` |
-[`pullrequest:comment_updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-updated) | specific commit | `pullrequest:comment_updated` |
-[`pullrequest:created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Created.1) | specific commit | `pullrequest:created` |
-[`pullrequest:fulfilled`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Merged) | specific commit | `pullrequest:fulfilled` |
-[`pullrequest:rejected`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Declined) | specific commit | `pullrequest:rejected` |
-[`pullrequest:unapproved`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Approval-removed) | specific commit | `pullrequest:unapproved` |
-[`pullrequest:updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Updated.2) | specific commit | `pullrequest:updated` |
-[`repo:commit_comment_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#hardBreak) | specific commit | `repo:commit_comment_created` |
-[`repo:commit_status_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Build-status-created) | specific commit | `repo:commit_status_created` |
-[`repo:commit_status_updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Build-status-updated) | specific commit | `repo:commit_status_updated` |
-[`repo:fork`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Fork) | specific repository | `repo:fork` |
-[`repo:push`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Push) | specific commit | `repo:push` |
-[`repo:updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Updated) | specific repository | `repo:updated` |
-
-## Examples Projects
-
-See `examples/` for complete Brigade projects that demonstrate various
-scenarios.
+* [Installation](docs/INSTALLATION.md): Check this out if you're an operator who
+  wants to integrate Bitbucket with your Brigade installation.
+* [Event Reference](docs/EVENT_REFERENCE.md): Check this out if you're a script
+  author or contributor who requires detailed information about all the webhooks
+  handled by this gateway and the corresponding events the gateway emits into
+  Brigade.
 
 ## Contributing
 

--- a/docs/EVENT_REFERENCE.md
+++ b/docs/EVENT_REFERENCE.md
@@ -1,0 +1,54 @@
+# Event Reference
+
+This section exists primarily for reference purposes and documents all Bitbucket
+webhooks which can be handled by this gateway and their corresponding Brigade
+events that may be emitted into the Brigade event bus.
+
+The transformation of a webhook into an event is relatively straightforward and
+subject to a few very simple rules:
+
+1. With every webhook handled by this gateway being indicative of activity
+   involving some specific repository, the name of the affected repository is
+   copied from the webhook's JSON payload and promoted to the `repo` qualifier
+   on the corresponding event. This permits projects to subscribe to events
+   relating only to specific repositories. Read more about qualifiers
+   [here](https://docs.brigade.sh/topics/project-developers/events/#qualifiers).
+
+1. For any webhook that is indicative of activity involving not only a specific
+   repository, but also some specific ref (branch or tag) or commit (identified
+   by SHA), this gateway copies those details from the webhook's JSON payload
+   and promotes them to the corresponding event's `git.ref` and/or `git.commit`
+   fields. By doing so, Brigade is enabled to locate specific code referenced by
+   the webhook/event. The importance of this cannot be understated, as it is
+   what permits Brigade to be used for implementing CI/CD pipelines.
+
+1. For _all_ webhooks, without exception, the entire JSON payload, without any
+   modification, becomes the corresponding event's `payload`. The event
+   `payload` field is a string field, however, so script authors wishing to
+   access the payload will need to parse the payload themselves with a
+   `JSON.parse()` call or similar.
+
+The following table summarizes all Bitbucket webhooks that can be handled by
+this gateway and the corresponding event(s) that are emitted into Brigade's
+event bus.
+
+| Webhook | Scope | Event Type(s) Emitted |
+|---------|-------|-----------------------|
+[`issue:comment_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-created) | specific repository | `issue:comment_created` |
+[`issue:created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Created) | specific repository | `issue:created` |
+[`issue:updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Updated.1) | specific repository | `issue:updated` |
+[`pullrequest:approved`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Approved) | specific commit | `pullrequest:approved` |
+[`pullrequest:comment_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-created.1) | specific commit | `pullrequest:comment_created` |
+[`pullrequest:comment_deleted`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-deleted) | specific commit | `pullrequest:comment_deleted` |
+[`pullrequest:comment_updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Comment-updated) | specific commit | `pullrequest:comment_updated` |
+[`pullrequest:created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Created.1) | specific commit | `pullrequest:created` |
+[`pullrequest:fulfilled`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Merged) | specific commit | `pullrequest:fulfilled` |
+[`pullrequest:rejected`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Declined) | specific commit | `pullrequest:rejected` |
+[`pullrequest:unapproved`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Approval-removed) | specific commit | `pullrequest:unapproved` |
+[`pullrequest:updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Updated.2) | specific commit | `pullrequest:updated` |
+[`repo:commit_comment_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#hardBreak) | specific commit | `repo:commit_comment_created` |
+[`repo:commit_status_created`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Build-status-created) | specific commit | `repo:commit_status_created` |
+[`repo:commit_status_updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Build-status-updated) | specific commit | `repo:commit_status_updated` |
+[`repo:fork`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Fork) | specific repository | `repo:fork` |
+[`repo:push`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Push) | specific commit | `repo:push` |
+[`repo:updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Updated) | specific repository | `repo:updated` |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,130 @@
+# Installation
+
+## Prerequisites
+
+* A Bitbucket account
+* A Kubernetes cluster:
+    * For which you have the `admin` cluster role.
+    * That is already running Brigade v2.0.0 or greater.
+    * That is capable of provisioning a _public IP address_ for a service of type
+    `LoadBalancer`.
+
+    > ⚠️&nbsp;&nbsp;This means you won't have much luck running the gateway
+    > locally in the likes of [KinD](https://kind.sigs.k8s.io/) or
+    > [minikube](https://minikube.sigs.k8s.io/docs/) unless you're able and
+    > willing to create port forwarding rules on your router or make use of a
+    > service such as [ngrok](https://ngrok.com/). Both of these are beyond
+    > the scope of this documentation.
+* `kubectl`
+* `helm`: Commands below require `helm` 3.7.0+.
+* `brig`: The Brigade CLI. Commands below require `brig` 2.0.0+.
+
+## Create a Service Account for the Gateway
+
+> ⚠️&nbsp;&nbsp;To proceed beyond this point, you'll need to be logged into
+> Brigade as the "root" user (not recommended) or (preferably) as a user with
+> the `ADMIN` role. Further discussion of this is beyond the scope of this
+> documentation. Please refer to Brigade's own documentation.
+
+1. Using the `brig` CLI, create a service account for the gateway to use:
+
+   ```shell
+   $ brig service-account create \
+       --id brigade-bitbucket-gateway \
+       --description "Used by the Brigade Bitbucket Gateway"
+   ```
+
+1. Make note of the __token__ returned. This value will be used in another step.
+
+   > ⚠️&nbsp;&nbsp;This is your only opportunity to access this value, as
+   > Brigade does not save it.
+
+1. Authorize this service account to create events:
+
+   ```shell
+   $ brig role grant EVENT_CREATOR \
+       --service-account brigade-bitbucket-gateway \
+       --source brigade.sh/bitbucket
+   ```
+
+   > ⚠️&nbsp;&nbsp;The `--source brigade.sh/bitbucket` option specifies that
+   > this service account can be used _only_ to create events having a value of
+   > `brigade.sh/bitbucket` in the event's `source` field. This is a security
+   > measure that prevents the gateway from using this token for impersonating
+   > other gateways.
+
+## Install the Gateway
+
+> ⚠️&nbsp;&nbsp;be sure you are using
+> [Helm 3.7.0](https://github.com/helm/helm/releases/tag/v3.7.0) or greater and
+> enable experimental OCI support:
+>
+> ```console
+>  $ export HELM_EXPERIMENTAL_OCI=1
+>  ```
+
+1. As this gateway requires some specific configuration to function properly,
+   we'll first create a values file containing those settings. Use the following
+   command to extract the full set of configuration options into a file you can
+   modify:
+
+   ```shell
+   $ helm inspect values oci://ghcr.io/brigadecore/brigade-bitbucket-gateway \
+    --version v2.0.0-beta.3 > ~/brigade-bitbucket-gateway-values.yaml
+   ```
+
+1. Edit `~/brigade-bitbucket-gateway-values.yaml`, making the following changes:
+
+   * `host`: Set this to the host name where you'd like the gateway to be
+     accessible.
+
+   * `brigade.apiAddress`: Set this to the address of the Brigade API server,
+     beginning with `https://`.
+
+   * `brigade.apiToken`: Set this to the service account token obtained when you
+     created the Brigade service account for this gateway.
+
+   * `service.type`: If you plan to enable ingress (advanced), you can leave
+     this as its default -- `ClusterIP`. If you do not plan to enable ingress,
+     you probably will want to change this value to `LoadBalancer`.
+
+   > ⚠️&nbsp;&nbsp;By default, TLS will be enabled and a self-signed certificate
+   > will be generated.
+   >
+   > For a production-grade deployment you should explore the options available
+   > for providing or provisioning a certificate signed by a trusted authority.
+   > These options can be located under the `tls` and `ingress.tls` sections of
+   > the values file.
+
+1. Save your changes to `~/brigade-bitbucket-gateway-values.yaml`.
+
+1. Use the following command to install the gateway:
+
+   ```shell
+   $ helm install brigade-bitbucket-gateway \
+       oci://ghcr.io/brigadecore/brigade-bitbucket-gateway \
+       --version v2.0.0-beta.3 \
+       --create-namespace \
+       --namespace brigade-bitbucket-gateway \
+       --values ~/brigade-bitbucket-gateway-values.yaml \
+       --wait \
+       --timeout 300s
+   ```
+
+## (RECOMMENDED) Create a DNS Entry
+
+If you overrode defaults and set `service.type` to `LoadBalancer`, use this
+command to find the gateway's public IP address:
+
+```console
+$ kubectl get svc brigade-bitbucket-gateway \
+    --namespace brigade-bitbucket-gateway \
+    --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+If you overrode default configuration to enable support for an ingress
+controller, you probably know what you're doing well enough to track down the
+correct IP for that ingress controller without our help. 😉
+
+With this public IP in hand, optionally edit your name servers and add an `A`
+record pointing a domain name to the public IP.


### PR DESCRIPTION
This is a big doc update that puts the README's focus on what the component does and moves installation instructions to a separate page. It's modeled after the GitHub gateway, which I think has the most mature docs of any of our peripherals.

After this, I'll cut an RC and PR some pre-release version bumps.

Planning to take this GA very soon.