### PR TITLE
chart: minor fixes relating to ingress

### DIFF
--- a/charts/brigade-bitbucket-gateway/templates/service.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/service.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "gateway.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
   externalTrafficPolicy: Local
+  {{- end }}
   ports:
   {{- if .Values.tls.enabled }}
   - port: 443

--- a/charts/brigade-bitbucket-gateway/values.yaml
+++ b/charts/brigade-bitbucket-gateway/values.yaml
@@ -44,9 +44,11 @@ tls:
   # key: base 64 encoded key goes here
 
 ingress:
-  ## Whether to enable ingress. By default, this is disabled and the gateway's
-  ## service is of type LoadBalancer instead. Enabling ingress is advanced
-  ## usage.
+  ## Whether to enable ingress. By default, this is disabled. Enabling ingress
+  ## is advanced usage.
+  ##
+  ## Note: This gateway requires access to the client's IP address, so only
+  ## ingress controllers that that set the X-FORWARDED-FOR header are supported.
   enabled: false
   ## Optionally use annotations specified by your ingress controller's
   ## documentation to customize the behavior of the ingress resource.


### PR DESCRIPTION
Fixes #37

I have confirmed that _at least_ the Nginx ingress controller is capable of setting the `X-Forwarded-For` header.