### PR TITLE
remove support for list of allowed events

### DIFF
--- a/charts/brigade-bitbucket-gateway/templates/deployment.yaml
+++ b/charts/brigade-bitbucket-gateway/templates/deployment.yaml
@@ -82,10 +82,6 @@ spec:
               key: brigadeAPIToken
         - name: API_IGNORE_CERT_WARNINGS
           value: {{ quote .Values.brigade.apiIgnoreCertWarnings }}
-        {{ if .Values.brigade.emittedEvents }}
-        - name: EMITTED_EVENTS
-          value: {{ join "," .Values.brigade.emittedEvents | quote }}
-        {{ end }}
         - name: ALLOWED_CLIENT_IPS
           value: {{ join "," .Values.allowedClientIPs | quote }}
         {{- if .Values.tls.enabled }}

--- a/charts/brigade-bitbucket-gateway/values.yaml
+++ b/charts/brigade-bitbucket-gateway/values.yaml
@@ -144,9 +144,3 @@ brigade:
   apiToken:
   ## Whether to ignore cert warning from the API server
   apiIgnoreCertWarnings: true
-  ## The opt-in list of upstream event types that may be emitted into Brigade.
-  ## Defaults to "*" which matches any event type. To emit only specific events
-  ## into Brigade, remove "*" and enumerate specific event types instead
-  ## (`pullrequest:created`, for instance).
-  emittedEvents:
-  - "*"

--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ package main
 import (
 	"net"
 
-	"github.com/brigadecore/brigade-bitbucket-gateway/internal/webhooks"
 	"github.com/brigadecore/brigade-foundations/http"
 	"github.com/brigadecore/brigade-foundations/os"
 	"github.com/brigadecore/brigade/sdk/v3/restmachinery"
@@ -25,17 +24,6 @@ func apiClientConfig() (string, string, restmachinery.APIClientOptions, error) {
 	opts.AllowInsecureConnections, err =
 		os.GetBoolFromEnvVar("API_IGNORE_CERT_WARNINGS", false)
 	return address, token, opts, err
-}
-
-// webhookServiceConfig populates configuration for the webhook-handling service
-// from environment variables.
-func webhookServiceConfig() webhooks.ServiceConfig {
-	return webhooks.ServiceConfig{
-		EmittedEvents: os.GetStringSliceFromEnvVar(
-			"EMITTED_EVENTS",
-			[]string{"*"},
-		),
-	}
 }
 
 // ipFilterConfig populates configuration for the IP web request filter.

--- a/config_test.go
+++ b/config_test.go
@@ -2,12 +2,9 @@ package main
 
 // nolint: lll
 import (
-	"io/ioutil"
 	"net"
-	"os"
 	"testing"
 
-	"github.com/brigadecore/brigade-bitbucket-gateway/internal/webhooks"
 	"github.com/brigadecore/brigade-foundations/http"
 	"github.com/brigadecore/brigade/sdk/v3/restmachinery"
 	"github.com/stretchr/testify/require"
@@ -83,51 +80,6 @@ func TestAPIClientConfig(t *testing.T) {
 			testCase.setup()
 			address, token, opts, err := apiClientConfig()
 			testCase.assertions(address, token, opts, err)
-		})
-	}
-}
-
-func TestWebHookServiceConfig(t *testing.T) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "")
-	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	_, err = tmpFile.Write([]byte("foo"))
-	require.NoError(t, err)
-	testCases := []struct {
-		name       string
-		setup      func()
-		assertions func(webhooks.ServiceConfig)
-	}{
-		{
-			name: "EMITTED_EVENTS not defined",
-			assertions: func(config webhooks.ServiceConfig) {
-				require.Equal(
-					t,
-					[]string{"*"},
-					config.EmittedEvents,
-				)
-			},
-		},
-		{
-			name: "EMITTED_EVENTS defined",
-			setup: func() {
-				t.Setenv("EMITTED_EVENTS", "foo,bar")
-			},
-			assertions: func(config webhooks.ServiceConfig) {
-				require.Equal(
-					t,
-					[]string{"foo", "bar"},
-					config.EmittedEvents,
-				)
-			},
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			if testCase.setup != nil {
-				testCase.setup()
-			}
-			testCase.assertions(webhookServiceConfig())
 		})
 	}
 }

--- a/internal/webhooks/service_test.go
+++ b/internal/webhooks/service_test.go
@@ -14,9 +14,7 @@ func TestNewService(t *testing.T) {
 		&sdkTesting.MockEventsClient{
 			LogsClient: &sdkTesting.MockLogsClient{},
 		},
-		ServiceConfig{},
 	).(*service)
 	require.True(t, ok)
 	require.NotNil(t, s.eventsClient)
-	require.NotNil(t, s.config)
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ func main() {
 		}
 		webhooksService = webhooks.NewService(
 			sdk.NewEventsClient(address, token, &opts),
-			webhookServiceConfig(),
 		)
 	}
 


### PR DESCRIPTION
Similar to https://github.com/brigadecore/brigade-github-gateway/pull/67

This feature made more sense for Brigade v1.x where we wanted to limit noise in the form of events that we were _never_ interested in.

With Brigade v2's subscription-based model, there's no noise resulting from events no one is interested in.